### PR TITLE
link to libgearman7 which is installed at /usr/lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup
 pygear = Extension(
     "pygear",
     sources=["pygear.c"],
+    runtime_library_dirs=["/usr/lib/"],  # libgearman7
     extra_link_args=["-l:libgearman.so.7"],
     extra_compile_args=["-I/usr/local/include", "-I/usr/include/python2.6/"]
 )


### PR DESCRIPTION
- don't link to libgearman-1.0.6 in /usr/local/lib/
- link to libgearman7 at /usr/lib/