### PR TITLE
Add garbage collector methods to pygear objects

### DIFF
--- a/client.c
+++ b/client.c
@@ -57,23 +57,42 @@ int Client_init(pygear_ClientObject* self, PyObject* args, PyObject*kwds) {
     return 0;
 }
 
+int Client_traverse(pygear_ClientObject* self, visitproc visit, void* arg)
+{
+    Py_VISIT(self->cb_workload);
+    Py_VISIT(self->cb_created);
+    Py_VISIT(self->cb_data);
+    Py_VISIT(self->cb_warning);
+    Py_VISIT(self->cb_status);
+    Py_VISIT(self->cb_complete);
+    Py_VISIT(self->cb_exception);
+    Py_VISIT(self->cb_fail);
+    Py_VISIT(self->cb_log);
+    Py_VISIT(self->serializer);
+    return 0;
+}
+
+int Client_clear(pygear_ClientObject* self)
+{
+    Py_CLEAR(self->cb_workload);
+    Py_CLEAR(self->cb_created);
+    Py_CLEAR(self->cb_data);
+    Py_CLEAR(self->cb_warning);
+    Py_CLEAR(self->cb_status);
+    Py_CLEAR(self->cb_complete);
+    Py_CLEAR(self->cb_exception);
+    Py_CLEAR(self->cb_fail);
+    Py_CLEAR(self->cb_log);
+    Py_CLEAR(self->serializer);
+    return 0;
+}
 
 void Client_dealloc(pygear_ClientObject* self) {
     if (self->g_Client) {
         gearman_client_free(self->g_Client);
         self->g_Client = NULL;
     }
-    // Decrement the reference count for callback functions, if they are set
-    Py_XDECREF(self->cb_workload);
-    Py_XDECREF(self->cb_created);
-    Py_XDECREF(self->cb_data);
-    Py_XDECREF(self->cb_warning);
-    Py_XDECREF(self->cb_status);
-    Py_XDECREF(self->cb_complete);
-    Py_XDECREF(self->cb_exception);
-    Py_XDECREF(self->cb_fail);
-    Py_XDECREF(self->cb_log);
-    Py_XDECREF(self->serializer);
+    Client_clear(self);
     self->ob_type->tp_free((PyObject*)self);
 }
 

--- a/client.c
+++ b/client.c
@@ -57,8 +57,7 @@ int Client_init(pygear_ClientObject* self, PyObject* args, PyObject*kwds) {
     return 0;
 }
 
-int Client_traverse(pygear_ClientObject* self, visitproc visit, void* arg)
-{
+int Client_traverse(pygear_ClientObject* self, visitproc visit, void* arg) {
     Py_VISIT(self->cb_workload);
     Py_VISIT(self->cb_created);
     Py_VISIT(self->cb_data);
@@ -72,8 +71,7 @@ int Client_traverse(pygear_ClientObject* self, visitproc visit, void* arg)
     return 0;
 }
 
-int Client_clear(pygear_ClientObject* self)
-{
+int Client_clear(pygear_ClientObject* self) {
     Py_CLEAR(self->cb_workload);
     Py_CLEAR(self->cb_created);
     Py_CLEAR(self->cb_data);

--- a/client.c
+++ b/client.c
@@ -32,16 +32,6 @@
  * Class constructor / destructor methods
  */
 
-PyObject* Client_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
-    pygear_ClientObject* self;
-    self = (pygear_ClientObject *)type->tp_alloc(type, 0);
-    if (self != NULL) {
-        self->g_Client = NULL;
-    }
-    return (PyObject *)self;
-}
-
-
 int Client_init(pygear_ClientObject* self, PyObject* args, PyObject*kwds) {
     self->g_Client = gearman_client_create(NULL);
     self->serializer = PyImport_ImportModule(PYTHON_SERIALIZER);

--- a/client.h
+++ b/client.h
@@ -60,7 +60,6 @@ typedef struct {
 PyDoc_STRVAR(client_module_docstring, "Represents a Gearman client.");
 
 /* Class init methods */
-PyObject* Client_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 int Client_init(pygear_ClientObject *self, PyObject *args, PyObject *kwds);
 void Client_dealloc(pygear_ClientObject* self);
 
@@ -480,8 +479,6 @@ PyTypeObject pygear_ClientType = {
     0,                                          /* tp_descr_set */
     0,                                          /* tp_dictoffset */
     (initproc)Client_init,                      /* tp_init */
-    0,                                          /* tp_alloc */
-    Client_new,                                 /* tp_new */
 };
 
 #endif

--- a/client.h
+++ b/client.h
@@ -61,6 +61,8 @@ PyDoc_STRVAR(client_module_docstring, "Represents a Gearman client.");
 
 /* Class init methods */
 int Client_init(pygear_ClientObject *self, PyObject *args, PyObject *kwds);
+int Client_traverse(pygear_ClientObject *self, visitproc visit, void *arg);
+int Client_clear(pygear_ClientObject *self);
 void Client_dealloc(pygear_ClientObject* self);
 
 
@@ -462,10 +464,12 @@ PyTypeObject pygear_ClientType = {
     0,                                          /*tp_getattro*/
     0,                                          /*tp_setattro*/
     0,                                          /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /*tp_flags*/
+    Py_TPFLAGS_DEFAULT |
+    Py_TPFLAGS_BASETYPE |
+    Py_TPFLAGS_HAVE_GC,                         /*tp_flags*/
     client_module_docstring,                    /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
+    (traverseproc)Client_traverse,              /* tp_traverse */
+    (inquiry)Client_clear,                      /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
     0,                                          /* tp_iter */

--- a/job.c
+++ b/job.c
@@ -32,16 +32,6 @@
  * Class constructor / destructor methods
  */
 
-PyObject* Job_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
-    pygear_JobObject* self;
-    self = (pygear_JobObject *)type->tp_alloc(type, 0);
-    if (self != NULL) {
-        self->g_Job = NULL;
-    }
-    self->serializer = NULL;
-    return (PyObject *)self;
-}
-
 int Job_init(pygear_JobObject* self, PyObject* args, PyObject* kwds) {
     self->g_Job = NULL;
     self->serializer = PyImport_ImportModule(PYTHON_SERIALIZER);

--- a/job.c
+++ b/job.c
@@ -44,14 +44,12 @@ int Job_init(pygear_JobObject* self, PyObject* args, PyObject* kwds) {
     return 0;
 }
 
-int Job_traverse(pygear_JobObject* self, visitproc visit, void* arg)
-{
+int Job_traverse(pygear_JobObject* self, visitproc visit, void* arg) {
     Py_VISIT(self->serializer);
     return 0;
 }
 
-int Job_clear(pygear_JobObject* self)
-{
+int Job_clear(pygear_JobObject* self) {
     Py_CLEAR(self->serializer);
     return 0;
 }

--- a/job.c
+++ b/job.c
@@ -44,12 +44,24 @@ int Job_init(pygear_JobObject* self, PyObject* args, PyObject* kwds) {
     return 0;
 }
 
+int Job_traverse(pygear_JobObject* self, visitproc visit, void* arg)
+{
+    Py_VISIT(self->serializer);
+    return 0;
+}
+
+int Job_clear(pygear_JobObject* self)
+{
+    Py_CLEAR(self->serializer);
+    return 0;
+}
+
 void Job_dealloc(pygear_JobObject* self) {
     if (self->g_Job) {
         gearman_job_free(self->g_Job);
         self->g_Job = NULL;
     }
-    Py_XDECREF(self->serializer);
+    Job_clear(self);
     self->ob_type->tp_free((PyObject*)self);
 }
 

--- a/job.h
+++ b/job.h
@@ -51,6 +51,8 @@ PyDoc_STRVAR(job_module_docstring, "Represents a Gearman job");
 
 /* Class init methods */
 int Job_init(pygear_JobObject *self, PyObject *args, PyObject *kwds);
+int Job_traverse(pygear_JobObject *self,  visitproc visit, void *arg);
+int Job_clear(pygear_JobObject* self);
 void Job_dealloc(pygear_JobObject* self);
 
 
@@ -157,10 +159,12 @@ PyTypeObject pygear_JobType = {
     0,                                          /*tp_getattro*/
     0,                                          /*tp_setattro*/
     0,                                          /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /*tp_flags*/
+    Py_TPFLAGS_DEFAULT |
+    Py_TPFLAGS_BASETYPE |
+    Py_TPFLAGS_HAVE_GC,                         /*tp_flags*/
     job_module_docstring,                       /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
+    (traverseproc)Job_traverse,                 /* tp_traverse */
+    (inquiry)Job_clear,                         /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
     0,                                          /* tp_iter */

--- a/job.h
+++ b/job.h
@@ -50,12 +50,11 @@ typedef struct {
 PyDoc_STRVAR(job_module_docstring, "Represents a Gearman job");
 
 /* Class init methods */
-PyObject* Job_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 int Job_init(pygear_JobObject *self, PyObject *args, PyObject *kwds);
 void Job_dealloc(pygear_JobObject* self);
 
-/* Method definitions */
 
+/* Method definitions */
 static PyObject* pygear_job_send_data(pygear_JobObject* self, PyObject* args);
 PyDoc_STRVAR(pygear_job_send_data_doc,
 "Send data for a running job.\n"
@@ -175,8 +174,6 @@ PyTypeObject pygear_JobType = {
     0,                                          /* tp_descr_set */
     0,                                          /* tp_dictoffset */
     (initproc)Job_init,                         /* tp_init */
-    0,                                          /* tp_alloc */
-    Job_new,                                    /* tp_new */
 };
 
 #endif

--- a/pygear.c
+++ b/pygear.c
@@ -56,7 +56,6 @@ PyMODINIT_FUNC initpygear(void) {
         return;
     }
 
-    pygear_AdminType.tp_new = PyType_GenericNew;
     if (PyType_Ready(&pygear_AdminType) < 0) {
         return;
     }

--- a/task.c
+++ b/task.c
@@ -44,12 +44,24 @@ int Task_init(pygear_TaskObject* self, PyObject* args, PyObject* kwds) {
     return 0;
 }
 
+int Task_traverse(pygear_TaskObject* self, visitproc visit, void* arg)
+{
+    Py_VISIT(self->serializer);
+    return 0;
+}
+
+int Task_clear(pygear_TaskObject* self)
+{
+    Py_CLEAR(self->serializer);
+    return 0;
+}
+
 void Task_dealloc(pygear_TaskObject* self) {
     if (self->g_Task) {
         gearman_task_free(self->g_Task);
         self->g_Task = NULL;
     }
-    Py_XDECREF(self->serializer);
+    Task_clear(self);
     self->ob_type->tp_free((PyObject*)self);
 }
 

--- a/task.c
+++ b/task.c
@@ -32,15 +32,6 @@
  * Class constructor / destructor methods
  */
 
-PyObject* Task_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
-    pygear_TaskObject* self;
-    self = (pygear_TaskObject *)type->tp_alloc(type, 0);
-    if (self != NULL) {
-        self->g_Task = NULL;
-    }
-    return (PyObject *)self;
-}
-
 int Task_init(pygear_TaskObject* self, PyObject* args, PyObject* kwds) {
     self->serializer = PyImport_ImportModule(PYTHON_SERIALIZER);
     if (self->serializer == NULL) {

--- a/task.c
+++ b/task.c
@@ -44,14 +44,12 @@ int Task_init(pygear_TaskObject* self, PyObject* args, PyObject* kwds) {
     return 0;
 }
 
-int Task_traverse(pygear_TaskObject* self, visitproc visit, void* arg)
-{
+int Task_traverse(pygear_TaskObject* self, visitproc visit, void* arg) {
     Py_VISIT(self->serializer);
     return 0;
 }
 
-int Task_clear(pygear_TaskObject* self)
-{
+int Task_clear(pygear_TaskObject* self) {
     Py_CLEAR(self->serializer);
     return 0;
 }

--- a/task.h
+++ b/task.h
@@ -50,6 +50,8 @@ PyDoc_STRVAR(task_module_docstring, "Represents a Gearman task");
 
 /* Class init methods */
 int Task_init(pygear_TaskObject *self, PyObject *args, PyObject *kwds);
+int Task_traverse(pygear_TaskObject *self,  visitproc visit, void *arg);
+int Task_clear(pygear_TaskObject* self);
 void Task_dealloc(pygear_TaskObject* self);
 
 /* Method definitions */
@@ -150,10 +152,12 @@ PyTypeObject pygear_TaskType = {
     0,                                          /*tp_getattro*/
     0,                                          /*tp_setattro*/
     0,                                          /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /*tp_flags*/
+    Py_TPFLAGS_DEFAULT |
+    Py_TPFLAGS_BASETYPE |
+    Py_TPFLAGS_HAVE_GC,                         /*tp_flags*/
     task_module_docstring,                      /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
+    (traverseproc)Task_traverse,                /* tp_traverse */
+    (inquiry)Task_clear,                        /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
     0,                                          /* tp_iter */

--- a/task.h
+++ b/task.h
@@ -49,7 +49,6 @@ typedef struct {
 PyDoc_STRVAR(task_module_docstring, "Represents a Gearman task");
 
 /* Class init methods */
-PyObject* Task_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 int Task_init(pygear_TaskObject *self, PyObject *args, PyObject *kwds);
 void Task_dealloc(pygear_TaskObject* self);
 
@@ -168,8 +167,6 @@ PyTypeObject pygear_TaskType = {
     0,                                          /* tp_descr_set */
     0,                                          /* tp_dictoffset */
     (initproc)Task_init,                        /* tp_init */
-    0,                                          /* tp_alloc */
-    Task_new,                                   /* tp_new */
 };
 
 #endif

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -18,6 +18,12 @@ class TestPygearAdminCommands(object):
             self.admin = pygear.Admin(self.sb_host, self.sb_port)
             yield
 
+    def test_defaults_from_new(self):
+        admin = pygear.Admin.__new__(pygear.Admin)
+        assert admin.info()['host'] is None
+        assert admin.info()['port'] == 4730
+        assert admin.info()['timeout'] == 60
+
     def test_admin_status(self):
         assert self.admin.status() == []
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,6 @@
+import gc
+
+import mock
 import pytest
 import pygear
 
@@ -152,3 +155,9 @@ def test_client_error(c):
     c.errno()
     c.error()
     c.error_code()
+
+
+def test_gc_traversal(c):
+    sentinel = mock.Mock()
+    c.set_complete_fn(sentinel)
+    assert sentinel in gc.get_referents(c)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,4 +1,7 @@
+import gc
 import multiprocessing
+
+import mock
 import pytest
 import pygear
 
@@ -56,3 +59,10 @@ def test_job_methods(c):
     worker_thread.start()
     c.run_tasks()
     worker_thread.join()
+
+
+def test_gc_traversal():
+    j = pygear.Job()
+    sentinel = mock.Mock()
+    j.set_serializer(sentinel)
+    assert sentinel in gc.get_referents(j)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,3 +1,6 @@
+import gc
+
+import mock
 import pytest
 import pygear
 
@@ -61,3 +64,9 @@ def test_task_strstate(t):
 
 def test_task_unique(t):
     assert t.unique() is None
+
+
+def test_gc_traversal(t):
+    sentinel = mock.Mock()
+    t.set_serializer(sentinel)
+    assert sentinel in gc.get_referents(t)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,3 +1,6 @@
+import gc
+
+import mock
 import pytest
 import pygear
 
@@ -138,3 +141,17 @@ def test_worker_misc(w):
     w.id()
     w.error()
     w.errno()
+
+
+def test_gc_traversal(w):
+    sentinel = mock.Mock()
+    w.set_serializer(sentinel)
+    assert sentinel in gc.get_referents(w)
+
+    sentinel = mock.Mock()
+    w.set_log_fn(sentinel, 0)
+    assert sentinel in gc.get_referents(w)
+
+    w.add_function("test_method", 60, echo_function)
+    print gc.get_referents(w)
+    assert {'test_method': echo_function} in gc.get_referents(w)

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ indexserver =
 [testenv]
 deps = -rrequirements-dev.txt
 commands =
-	py.test
+	py.test {posargs}
 
 [testenv:py]
 deps = {[testenv]deps}

--- a/worker.c
+++ b/worker.c
@@ -32,16 +32,6 @@
  * Class constructor / destructor methods
  */
 
-PyObject* Worker_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
-    pygear_WorkerObject* self = NULL;
-    self = (pygear_WorkerObject *)type->tp_alloc(type, 0);
-    if (self != NULL) {
-        self->g_Worker = NULL;
-        self->g_FunctionMap = NULL;
-    }
-    return (PyObject *)self;
-}
-
 /* Return -1 if fail, 0 if success */
 int Worker_init(pygear_WorkerObject* self, PyObject* args, PyObject* kwds) {
     self->g_Worker = gearman_worker_create(NULL);

--- a/worker.c
+++ b/worker.c
@@ -58,14 +58,26 @@ int Worker_init(pygear_WorkerObject* self, PyObject* args, PyObject* kwds) {
     return 0;
 }
 
+int Worker_traverse(pygear_WorkerObject *self,  visitproc visit, void *arg) {
+    Py_VISIT(self->g_FunctionMap);
+    Py_VISIT(self->serializer);
+    Py_VISIT(self->cb_log);
+    return 0;
+}
+
+int Worker_clear(pygear_WorkerObject* self) {
+    Py_CLEAR(self->g_FunctionMap);
+    Py_CLEAR(self->serializer);
+    Py_CLEAR(self->cb_log);
+    return 0;
+}
+
 void Worker_dealloc(pygear_WorkerObject* self) {
     if (self->g_Worker) {
         gearman_worker_free(self->g_Worker);
         self->g_Worker = NULL;
     }
-    Py_XDECREF(self->g_FunctionMap);
-    Py_XDECREF(self->serializer);
-    Py_XDECREF(self->cb_log);
+    Worker_clear(self);
     self->ob_type->tp_free((PyObject*)self);
 }
 
@@ -659,7 +671,7 @@ catch:
         *ret_ptr = GEARMAN_SUCCESS;
     } else if (retptr == FAIL) {
         *ret_ptr = GEARMAN_FAIL;
-    } else { 
+    } else {
         // ret_ptr remain unchanged, same as input
     }
     return NULL;

--- a/worker.h
+++ b/worker.h
@@ -52,6 +52,8 @@ PyDoc_STRVAR(worker_module_docstring, "Represents a Gearman worker.");
 
 /* Class init methods */
 int Worker_init(pygear_WorkerObject *self, PyObject *args, PyObject *kwds);
+int Worker_traverse(pygear_WorkerObject *self,  visitproc visit, void *arg);
+int Worker_clear(pygear_WorkerObject* self);
 void Worker_dealloc(pygear_WorkerObject* self);
 
 /* Private methods */
@@ -307,10 +309,12 @@ PyTypeObject pygear_WorkerType = {
     0,                                          /*tp_getattro*/
     0,                                          /*tp_setattro*/
     0,                                          /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /*tp_flags*/
+    Py_TPFLAGS_DEFAULT |
+    Py_TPFLAGS_BASETYPE |
+    Py_TPFLAGS_HAVE_GC,                         /*tp_flags*/
     worker_module_docstring,                    /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
+    (traverseproc)Worker_traverse,              /* tp_traverse */
+    (inquiry)Worker_clear,                      /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
     0,                                          /* tp_iter */

--- a/worker.h
+++ b/worker.h
@@ -51,7 +51,6 @@ typedef struct {
 PyDoc_STRVAR(worker_module_docstring, "Represents a Gearman worker.");
 
 /* Class init methods */
-PyObject* Worker_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 int Worker_init(pygear_WorkerObject *self, PyObject *args, PyObject *kwds);
 void Worker_dealloc(pygear_WorkerObject* self);
 
@@ -325,8 +324,6 @@ PyTypeObject pygear_WorkerType = {
     0,                                          /* tp_descr_set */
     0,                                          /* tp_dictoffset */
     (initproc)Worker_init,                      /* tp_init */
-    0,                                          /* tp_alloc */
-    Worker_new,                                 /* tp_new */
 };
 
 #endif


### PR DESCRIPTION
This change adds tp_traverse to pygear objects that have references to other python objects, and thus allows the garbage collector to detect if they've entered into a cycle.

I've also cleaned up a bunch of _new functions. They weren't doing anything the PyType_GenericNew doesn't do, and they were being overwritten by the PyType_GenericNew in pygear.c anyways. The one exception is Admin_new, which did things, and is now not being overwritten. 