### PR TITLE
catch last error from libgearman

### DIFF
--- a/client.c
+++ b/client.c
@@ -107,7 +107,7 @@ static PyObject* pygear_client_add_server(pygear_ClientObject* self, PyObject* a
         return NULL;
     }
     gearman_return_t result = gearman_client_add_server(self->g_Client, host, port);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_client_error(self->g_Client))) {
         return NULL;
     }
     // gearman_client_set_exception_fn() will only be called if exceptions are enabled on the server
@@ -139,7 +139,7 @@ static PyObject* pygear_client_add_servers(pygear_ClientObject* self, PyObject* 
     for (i = 0; i < num_servers; ++i) {
         char* server_string = PyString_AsString(PyList_GetItem(server_list, i));
         gearman_return_t result = gearman_client_add_servers(self->g_Client, server_string);
-        if (_pygear_check_and_raise_exn(result)) {
+        if (_pygear_check_and_raise_exn(result, gearman_client_error(self->g_Client))) {
             return NULL;
         }
     }
@@ -189,7 +189,7 @@ static PyObject* pygear_client_add_task##TASKTYPE(pygear_ClientObject* self, PyO
         workload_size, \
         &ret \
     ); \
-    if (_pygear_check_and_raise_exn(ret)) { \
+    if (_pygear_check_and_raise_exn(ret, gearman_client_error(self->g_Client))) { \
         return NULL; \
     } \
     /* Creating new python task */ \
@@ -233,7 +233,7 @@ static PyObject* pygear_client_add_task_status(pygear_ClientObject* self, PyObje
         job_handle,
         &gearman_return
     );
-    if (_pygear_check_and_raise_exn(gearman_return)) {
+    if (_pygear_check_and_raise_exn(gearman_return, gearman_client_error(self->g_Client))) {
         return NULL;
     }
     pygear_TaskObject* python_task = (pygear_TaskObject*) _PyObject_New(&pygear_TaskType);
@@ -310,7 +310,7 @@ static PyObject* pygear_client_do##DOTYPE(pygear_ClientObject* self, PyObject* a
         &result_size, \
         &ret); /* work_result must be freed later to avoid memory leak */ \
     Py_XDECREF(pickled_input); /* safely dealloc workload */ \
-    if (_pygear_check_and_raise_exn(ret)) { \
+    if (_pygear_check_and_raise_exn(ret, gearman_client_error(self->g_Client))) { \
         free(work_result); \
         return NULL; \
     } \
@@ -364,7 +364,7 @@ static PyObject* pygear_client_do##DOTYPE##_background(pygear_ClientObject* self
         job_handle \
     ); \
     Py_XDECREF(pickled_input); /* safely dealloc workload */ \
-    if (_pygear_check_and_raise_exn(work_result)) { \
+    if (_pygear_check_and_raise_exn(work_result, gearman_client_error(self->g_Client))) { \
         free(job_handle); \
         return NULL; \
     } \
@@ -400,7 +400,7 @@ static PyObject* pygear_client_echo(pygear_ClientObject* self, PyObject* args) {
         return NULL;
     }
     gearman_return_t result = gearman_client_echo(self->g_Client, workload, workload_len);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_client_error(self->g_Client))) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -456,7 +456,7 @@ static PyObject* pygear_client_execute(pygear_ClientObject* self, PyObject* args
         NULL // context
     );
     if (new_task == NULL) {
-        if (_pygear_check_and_raise_exn(gearman_client_errno(self->g_Client))) {
+        if (_pygear_check_and_raise_exn(gearman_client_errno(self->g_Client), gearman_client_error(self->g_Client))) {
             return NULL;
         }
     }
@@ -469,7 +469,7 @@ static PyObject* pygear_client_execute(pygear_ClientObject* self, PyObject* args
         goto catch;
     }
     // Make sure the task was run successfully
-    if (_pygear_check_and_raise_exn(gearman_task_return(new_task))) {
+    if (_pygear_check_and_raise_exn(gearman_task_return(new_task), gearman_client_error(self->g_Client))) {
         goto catch;
     }
     // Make use of the result
@@ -527,7 +527,7 @@ static PyObject* pygear_client_job_status(pygear_ClientObject* self, PyObject* a
         &is_known, &is_running,
         &numerator, &denominator
     );
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_client_error(self->g_Client))) {
         return NULL;
     }
     PyObject* status_dict = Py_BuildValue(
@@ -549,7 +549,7 @@ static PyObject* pygear_client_remove_servers(pygear_ClientObject* self) {
 
 static PyObject* pygear_client_run_tasks(pygear_ClientObject* self) {
     gearman_return_t result = gearman_client_run_tasks(self->g_Client);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_client_error(self->g_Client))) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -718,7 +718,7 @@ static PyObject* pygear_client_unique_status(pygear_ClientObject* self, PyObject
         return NULL;
     }
     gearman_status_t status = gearman_client_unique_status(self->g_Client, unique, unique_len);
-    if (_pygear_check_and_raise_exn(status.status_.mesg_.result_rc)) {
+    if (_pygear_check_and_raise_exn(status.status_.mesg_.result_rc, gearman_client_error(self->g_Client))) {
         return NULL;
     }
     PyObject* status_dict = Py_BuildValue(
@@ -734,7 +734,7 @@ static PyObject* pygear_client_unique_status(pygear_ClientObject* self, PyObject
 
 static PyObject* pygear_client_wait(pygear_ClientObject* self) {
     gearman_return_t result = gearman_client_wait(self->g_Client);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_client_error(self->g_Client))) {
         return NULL;
     }
     Py_RETURN_NONE;

--- a/exception.h
+++ b/exception.h
@@ -89,6 +89,6 @@ PyObject* PyGearExn_MAX_RETURN; /* Always add new error code before */
  *
  * Return: 0 on no error, 1 on error.
  */
-int _pygear_check_and_raise_exn(gearman_return_t return_code);
+int _pygear_check_and_raise_exn(gearman_return_t return_code, const char* error);
 
 #endif

--- a/job.c
+++ b/job.c
@@ -105,7 +105,7 @@ static PyObject* pygear_job_send_data(pygear_JobObject* self, PyObject* args) {
     }
     Py_XDECREF(pickled_data);
     gearman_return_t result = gearman_job_send_data(self->g_Job, c_data, c_data_size);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, "Failed in gearman_job_send_data")) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -129,7 +129,7 @@ static PyObject* pygear_job_send_warning(pygear_JobObject* self, PyObject* args)
     }
     Py_XDECREF(pickled_data);
     gearman_return_t result = gearman_job_send_warning(self->g_Job, c_data, c_data_size);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, "Failed in gearman_job_send_warning")) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -141,7 +141,7 @@ static PyObject* pygear_job_send_status(pygear_JobObject* self, PyObject* args) 
         return NULL;
     }
     gearman_return_t result = gearman_job_send_status(self->g_Job, numerator, denominator);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, "Failed in gearman_job_send_status")) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -165,7 +165,7 @@ static PyObject* pygear_job_send_complete(pygear_JobObject* self, PyObject* args
     }
     Py_XDECREF(pickled_result); 
     gearman_return_t gearman_result = gearman_job_send_complete(self->g_Job, c_result, c_result_size);
-    if (_pygear_check_and_raise_exn(gearman_result)) {
+    if (_pygear_check_and_raise_exn(gearman_result, "Failed in gearman_job_send_complete")) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -190,7 +190,7 @@ static PyObject* pygear_job_send_exception(pygear_JobObject* self, PyObject* arg
     }
     Py_XDECREF(pickled_data);
     gearman_return_t result = gearman_job_send_exception(self->g_Job, c_data, c_data_size);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, "Failed in gearman_job_send_exception")) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -198,7 +198,7 @@ static PyObject* pygear_job_send_exception(pygear_JobObject* self, PyObject* arg
 
 static PyObject* pygear_job_send_fail(pygear_JobObject* self) {
     gearman_return_t result = gearman_job_send_fail(self->g_Job);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, "Failed in gearman_job_send_fail")) {
         return NULL;
     }
     Py_RETURN_NONE;

--- a/pygear.c
+++ b/pygear.c
@@ -145,63 +145,63 @@ PyMODINIT_FUNC initpygear(void) {
     INIT_EXN(MAX_RETURN); /* Always add new error code before */
 }
 
-#define EXN_CASE_RAISE(EXN) \
+#define EXN_CASE_RAISE(EXN, ERR) \
 case GEARMAN_##EXN: { \
-    PyErr_SetString(PyGearExn_##EXN, #EXN); \
+    PyErr_SetString(PyGearExn_##EXN, ERR); \
     return 1; \
 }
 
-int _pygear_check_and_raise_exn(gearman_return_t returncode) {
+int _pygear_check_and_raise_exn(gearman_return_t returncode, const char* error) {
     switch (returncode) {
-        EXN_CASE_RAISE(SHUTDOWN);
-        EXN_CASE_RAISE(SHUTDOWN_GRACEFUL);
-        EXN_CASE_RAISE(ERRNO);
-        EXN_CASE_RAISE(EVENT); // DEPRECATED; SERVER ONLY
-        EXN_CASE_RAISE(TOO_MANY_ARGS);
-        EXN_CASE_RAISE(NO_ACTIVE_FDS); // No servers available
-        EXN_CASE_RAISE(INVALID_MAGIC);
-        EXN_CASE_RAISE(INVALID_COMMAND);
-        EXN_CASE_RAISE(INVALID_PACKET);
-        EXN_CASE_RAISE(UNEXPECTED_PACKET);
-        EXN_CASE_RAISE(GETADDRINFO);
-        EXN_CASE_RAISE(NO_SERVERS);
-        EXN_CASE_RAISE(LOST_CONNECTION);
-        EXN_CASE_RAISE(MEMORY_ALLOCATION_FAILURE);
-        EXN_CASE_RAISE(JOB_EXISTS); // see gearman_client_job_status()
-        EXN_CASE_RAISE(JOB_QUEUE_FULL);
-        EXN_CASE_RAISE(SERVER_ERROR);
-        EXN_CASE_RAISE(WORK_ERROR);
-        EXN_CASE_RAISE(WORK_DATA);
-        EXN_CASE_RAISE(WORK_WARNING);
-        EXN_CASE_RAISE(WORK_STATUS);
-        EXN_CASE_RAISE(WORK_EXCEPTION);
-        EXN_CASE_RAISE(WORK_FAIL);
-        EXN_CASE_RAISE(NOT_CONNECTED);
-        EXN_CASE_RAISE(COULD_NOT_CONNECT);
-        EXN_CASE_RAISE(SEND_IN_PROGRESS); // DEPRECATED; SERVER ONLY
-        EXN_CASE_RAISE(RECV_IN_PROGRESS); // DEPRECATED; SERVER ONLY
-        EXN_CASE_RAISE(NOT_FLUSHING);
-        EXN_CASE_RAISE(DATA_TOO_LARGE);
-        EXN_CASE_RAISE(INVALID_FUNCTION_NAME);
-        EXN_CASE_RAISE(INVALID_WORKER_FUNCTION);
-        EXN_CASE_RAISE(NO_REGISTERED_FUNCTION);
-        EXN_CASE_RAISE(NO_REGISTERED_FUNCTIONS);
-        EXN_CASE_RAISE(NO_JOBS);
-        EXN_CASE_RAISE(ECHO_DATA_CORRUPTION);
-        EXN_CASE_RAISE(NEED_WORKLOAD_FN);
-        EXN_CASE_RAISE(UNKNOWN_STATE);
-        EXN_CASE_RAISE(PTHREAD); // DEPRECATED; SERVER ONLY
-        EXN_CASE_RAISE(PIPE_EOF); // DEPRECATED; SERVER ONLY
-        EXN_CASE_RAISE(QUEUE_ERROR); // DEPRECATED; SERVER ONLY
-        EXN_CASE_RAISE(FLUSH_DATA); // Internal state
-        EXN_CASE_RAISE(SEND_BUFFER_TOO_SMALL);
-        EXN_CASE_RAISE(IGNORE_PACKET); // Internal only
-        EXN_CASE_RAISE(UNKNOWN_OPTION); // DEPRECATED
-        EXN_CASE_RAISE(TIMEOUT);
-        EXN_CASE_RAISE(ARGUMENT_TOO_LARGE);
-        EXN_CASE_RAISE(INVALID_ARGUMENT);
-        EXN_CASE_RAISE(INVALID_SERVER_OPTION); // Bad server option sent to server
-        EXN_CASE_RAISE(MAX_RETURN); /* Always add new error code before */
+        EXN_CASE_RAISE(SHUTDOWN, error);
+        EXN_CASE_RAISE(SHUTDOWN_GRACEFUL, error);
+        EXN_CASE_RAISE(ERRNO, error);
+        EXN_CASE_RAISE(EVENT, error); // DEPRECATED; SERVER ONLY
+        EXN_CASE_RAISE(TOO_MANY_ARGS, error);
+        EXN_CASE_RAISE(NO_ACTIVE_FDS, error); // No servers available
+        EXN_CASE_RAISE(INVALID_MAGIC, error);
+        EXN_CASE_RAISE(INVALID_COMMAND, error);
+        EXN_CASE_RAISE(INVALID_PACKET, error);
+        EXN_CASE_RAISE(UNEXPECTED_PACKET, error);
+        EXN_CASE_RAISE(GETADDRINFO, error);
+        EXN_CASE_RAISE(NO_SERVERS, error);
+        EXN_CASE_RAISE(LOST_CONNECTION, error);
+        EXN_CASE_RAISE(MEMORY_ALLOCATION_FAILURE, error);
+        EXN_CASE_RAISE(JOB_EXISTS, error); // see gearman_client_job_status()
+        EXN_CASE_RAISE(JOB_QUEUE_FULL, error);
+        EXN_CASE_RAISE(SERVER_ERROR, error);
+        EXN_CASE_RAISE(WORK_ERROR, error);
+        EXN_CASE_RAISE(WORK_DATA, error);
+        EXN_CASE_RAISE(WORK_WARNING, error);
+        EXN_CASE_RAISE(WORK_STATUS, error);
+        EXN_CASE_RAISE(WORK_EXCEPTION, error);
+        EXN_CASE_RAISE(WORK_FAIL, error);
+        EXN_CASE_RAISE(NOT_CONNECTED, error);
+        EXN_CASE_RAISE(COULD_NOT_CONNECT, error);
+        EXN_CASE_RAISE(SEND_IN_PROGRESS, error); // DEPRECATED; SERVER ONLY
+        EXN_CASE_RAISE(RECV_IN_PROGRESS, error); // DEPRECATED; SERVER ONLY
+        EXN_CASE_RAISE(NOT_FLUSHING, error);
+        EXN_CASE_RAISE(DATA_TOO_LARGE, error);
+        EXN_CASE_RAISE(INVALID_FUNCTION_NAME, error);
+        EXN_CASE_RAISE(INVALID_WORKER_FUNCTION, error);
+        EXN_CASE_RAISE(NO_REGISTERED_FUNCTION, error);
+        EXN_CASE_RAISE(NO_REGISTERED_FUNCTIONS, error);
+        EXN_CASE_RAISE(NO_JOBS, error);
+        EXN_CASE_RAISE(ECHO_DATA_CORRUPTION, error);
+        EXN_CASE_RAISE(NEED_WORKLOAD_FN, error);
+        EXN_CASE_RAISE(UNKNOWN_STATE, error);
+        EXN_CASE_RAISE(PTHREAD, error); // DEPRECATED; SERVER ONLY
+        EXN_CASE_RAISE(PIPE_EOF, error); // DEPRECATED; SERVER ONLY
+        EXN_CASE_RAISE(QUEUE_ERROR, error); // DEPRECATED; SERVER ONLY
+        EXN_CASE_RAISE(FLUSH_DATA, error); // Internal state
+        EXN_CASE_RAISE(SEND_BUFFER_TOO_SMALL, error);
+        EXN_CASE_RAISE(IGNORE_PACKET, error); // Internal only
+        EXN_CASE_RAISE(UNKNOWN_OPTION, error); // DEPRECATED
+        EXN_CASE_RAISE(TIMEOUT, error);
+        EXN_CASE_RAISE(ARGUMENT_TOO_LARGE, error);
+        EXN_CASE_RAISE(INVALID_ARGUMENT, error);
+        EXN_CASE_RAISE(INVALID_SERVER_OPTION, error); // Bad server option sent to server
+        EXN_CASE_RAISE(MAX_RETURN, error); /* Always add new error code before */
         default:
             return 0;
     }

--- a/worker.c
+++ b/worker.c
@@ -104,7 +104,7 @@ static PyObject* pygear_worker_add_function(pygear_WorkerObject* self, PyObject*
         _pygear_worker_function_mapper,
         self
     );
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_worker_error(self->g_Worker))) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -118,7 +118,7 @@ static PyObject* pygear_worker_add_server(pygear_WorkerObject* self, PyObject* a
         return NULL;
     }
     gearman_return_t result = gearman_worker_add_server(self->g_Worker, host, port);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_worker_error(self->g_Worker))) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -148,7 +148,7 @@ static PyObject* pygear_worker_add_servers(pygear_WorkerObject* self, PyObject* 
     for (i = 0; i < num_servers; ++i) {
         char* server_string = PyString_AsString(PyList_GetItem(servers_list, i));
         gearman_return_t result = gearman_worker_add_servers(self->g_Worker, server_string);
-        if (_pygear_check_and_raise_exn(result)) {
+        if (_pygear_check_and_raise_exn(result, gearman_worker_error(self->g_Worker))) {
             goto catch;
         }
     }
@@ -187,7 +187,7 @@ static PyObject* pygear_worker_echo(pygear_WorkerObject* self, PyObject* args) {
         workload,
         workload_size
     );
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_worker_error(self->g_Worker))) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -274,7 +274,7 @@ static PyObject* pygear_worker_grab_job(pygear_WorkerObject* self) {
     pygear_JobObject* python_job = NULL;
     PyObject* callmethod_result = NULL;
     PyObject* ret = NULL;
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_worker_error(self->g_Worker))) {
         goto catch;
     }
     argList = Py_BuildValue("(O, O)", Py_None, Py_None);
@@ -326,7 +326,7 @@ static PyObject* pygear_worker_register(pygear_WorkerObject* self, PyObject* arg
         return NULL;
     }
     gearman_return_t result = gearman_worker_register(self->g_Worker, function_name, timeout);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_worker_error(self->g_Worker))) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -346,7 +346,7 @@ static PyObject* pygear_worker_set_identifier(pygear_WorkerObject* self, PyObjec
         return NULL;
     }
     gearman_return_t result = gearman_worker_set_identifier(self->g_Worker, id, id_size);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_worker_error(self->g_Worker))) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -483,7 +483,7 @@ static PyObject* pygear_worker_timeout(pygear_WorkerObject* self) {
 
 static PyObject* pygear_worker_wait(pygear_WorkerObject* self) {
     gearman_return_t result = gearman_worker_wait(self->g_Worker);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_worker_error(self->g_Worker))) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -642,7 +642,7 @@ void* _pygear_worker_function_mapper(gearman_job_st* gear_job, void* context,
             Py_ssize_t len;
             char* buffer;
             PyString_AsStringAndSize(pickled_result, &buffer, &len);
-            if (_pygear_check_and_raise_exn(gearman_job_send_complete(gear_job, buffer, len))) {
+            if (_pygear_check_and_raise_exn(gearman_job_send_complete(gear_job, buffer, len), "Failed in gearman_job_send_complete")) {
                 PyErr_Print();
                 retptr = UNDEFINED;
             } else {
@@ -683,7 +683,7 @@ static PyObject* pygear_worker_work(pygear_WorkerObject* self) {
     if (PyErr_Occurred()) {
         return NULL;
     }
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_worker_error(self->g_Worker))) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -696,7 +696,7 @@ static PyObject* pygear_worker_unregister(pygear_WorkerObject* self, PyObject* a
         return NULL;
     }
     gearman_return_t result = gearman_worker_unregister(self->g_Worker, function_name);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_worker_error(self->g_Worker))) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -705,7 +705,7 @@ static PyObject* pygear_worker_unregister(pygear_WorkerObject* self, PyObject* a
 
 static PyObject* pygear_worker_unregister_all(pygear_WorkerObject* self) {
     gearman_return_t result = gearman_worker_unregister_all(self->g_Worker);
-    if (_pygear_check_and_raise_exn(result)) {
+    if (_pygear_check_and_raise_exn(result, gearman_worker_error(self->g_Worker))) {
         return NULL;
     }
     Py_RETURN_NONE;


### PR DESCRIPTION
current pygear does not show the error message from libgearman when the exception is raised.
gearman_client_error() and gearman_worker_error() reported the last error occured in client/worker.