### PR TITLE
use simplejson as default serializer

### DIFF
--- a/client.h
+++ b/client.h
@@ -330,7 +330,7 @@ PyDoc_STRVAR(pygear_client_set_options_doc,
 static PyObject* pygear_client_set_serializer(pygear_ClientObject* self, PyObject* args);
 PyDoc_STRVAR(pygear_client_set_serializer_doc,
 "Specify the object to be used to serialize data passed through gearman.\n"
-"By default, pygear will use 'json' to convert data to a string\n"
+"By default, pygear will use 'simplejson' to convert data to a string\n"
 "representation during transit and reconstitute it on the other end.\n"
 "You can replace the serializer with your own as long as it implements\n"
 "the 'dumps' and 'loads' methods. 'dumps' must return a string, and loads\n"

--- a/pygear.h
+++ b/pygear.h
@@ -29,7 +29,7 @@
 #ifndef PYGEAR_H
 #define PYGEAR_H
 
-#define PYTHON_SERIALIZER "json"
+#define PYTHON_SERIALIZER "simplejson"
 
 #include <Python.h>
 #include <libgearman-1.0/gearman.h>

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,8 @@ setup(
         'flake8',
         'pylint',
         'sphinx'
+    ],
+    install_requires=[
+        'simplejson',
     ]
 )

--- a/task.h
+++ b/task.h
@@ -106,7 +106,7 @@ PyDoc_STRVAR(pygear_task_data_size_doc,
 static PyObject* pygear_task_set_serializer(pygear_TaskObject* self, PyObject* args);
 PyDoc_STRVAR(pygear_task_set_serializer_doc,
 "Specify the object to be used to serialize data passed through gearman.\n"
-"By default, pygear will use 'json' to convert data to a string\n"
+"By default, pygear will use 'simplejson' to convert data to a string\n"
 "representation during transit and reconstitute it on the other end.\n"
 "You can replace the serializer with your own as long as it implements\n"
 "the 'dumps' and 'loads' methods. 'dumps' must return a string, and loads\n"

--- a/worker.h
+++ b/worker.h
@@ -213,7 +213,7 @@ PyDoc_STRVAR(pygear_worker_set_options_doc,
 static PyObject* pygear_worker_set_serializer(pygear_WorkerObject* self, PyObject* args);
 PyDoc_STRVAR(pygear_worker_set_serializer_doc,
 "Specify the object to be used to serialize data passed through gearman.\n"
-"By default, pygear will use 'json' to convert data to a string\n"
+"By default, pygear will use 'simplejson' to convert data to a string\n"
 "representation during transit and reconstitute it on the other end.\n"
 "You can replace the serializer with your own as long as it implements\n"
 "the 'dumps' and 'loads' methods. 'dumps' must return a string, and loads\n"


### PR DESCRIPTION
json and simplejson encode namedtuple differently.
http://robotfantastic.org/serializing-python-data-to-json-some-edge-cases.html
we prefer it to be encoded as dict.