### PR TITLE
Test under py27

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
-envlist = py26
-indexserver =
-	default = https://pypi.yelpcorp.com/simple/
+envlist = py26,py27
 
 [testenv]
 deps = -rrequirements-dev.txt
@@ -33,8 +31,7 @@ envdir = virtualenv_run
 commands =
 
 [flake8]
-exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,docs,virtualenv_run
-filename = *.py,*.wsgi
+exclude = .git,__pycache__,.tox,docs,virtualenv_run
 
 [pytest]
-norecursedirs = .* _darcs CVS docs virtualenv_run
+norecursedirs = .* docs virtualenv_run


### PR DESCRIPTION
```
$ tox -e py26,py27GLOB sdist-make: /nail/home/asottile/trees/pygear/setup.py
py26 inst-nodeps: /nail/home/asottile/trees/pygear/.tox/dist/pygear-0.9.2.zip
py26 runtests: commands[0] | py.test
============================= test session starts ==============================
platform linux2 -- Python 2.6.7 -- py-1.4.20 -- pytest-2.5.2
collected 92 items / 2 skipped 

tests/test_admin.py ................
tests/test_client.py ..........................
tests/test_integration.py .........
tests/test_job.py ..
tests/test_task.py ..............
tests/test_worker.py .........................

==================== 92 passed, 2 skipped in 21.38 seconds =====================
py27 inst-nodeps: /nail/home/asottile/trees/pygear/.tox/dist/pygear-0.9.2.zip
py27 runtests: commands[0] | py.test
============================= test session starts ==============================
platform linux2 -- Python 2.7.6 -- py-1.4.20 -- pytest-2.5.2
collected 92 items / 2 skipped 

tests/test_admin.py ................
tests/test_client.py ..........................
tests/test_integration.py .........
tests/test_job.py ..
tests/test_task.py ..............
tests/test_worker.py .........................

==================== 92 passed, 2 skipped in 21.53 seconds =====================
___________________________________ summary ____________________________________
  py26: commands succeeded
  py27: commands succeeded
  congratulations :)
```