### PR TITLE
Don't explicitly include python headers, they're automatic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ pygear = Extension(
     sources=["pygear.c"],
     runtime_library_dirs=["/usr/lib/"],  # libgearman7
     extra_link_args=["-l:libgearman.so.7"],
-    extra_compile_args=["-I/usr/local/include", "-I/usr/include/python2.6/"]
 )
 
 


### PR DESCRIPTION
Here's tox output:

```
$ git clean -fxfd && tox -e py26
Removing .tox/
Removing pygear.egg-info/
Removing tests/__init__.pyc
Removing tests/__pycache__/
Removing tests/sandbox.pyc
GLOB sdist-make: /nail/home/asottile/trees/pygear/setup.py
py26 create: /nail/home/asottile/trees/pygear/.tox/py26
py26 installdeps: -rrequirements-dev.txt
py26 inst: /nail/home/asottile/trees/pygear/.tox/dist/pygear-0.9.2.zip
py26 runtests: commands[0] | py.test
============================= test session starts ==============================
platform linux2 -- Python 2.6.7 -- py-1.4.20 -- pytest-2.5.2
collected 92 items / 2 skipped 

tests/test_admin.py ................
tests/test_client.py ..........................
tests/test_integration.py .........
tests/test_job.py ..
tests/test_task.py ..............
tests/test_worker.py .........................

==================== 92 passed, 2 skipped in 21.68 seconds =====================
___________________________________ summary ____________________________________
  py26: commands succeeded
  congratulations :)
```