### PR TITLE
Use SSL to talk to pypi

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = py26
 indexserver =
-	default = http://pypi.yelpcorp.com/simple/
+	default = https://pypi.yelpcorp.com/simple/
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Should not change any behaviour (sort of getting rid of warnings).